### PR TITLE
Terraform v0.13 syntax change: google provider

### DIFF
--- a/examples/client-certificate/main.tf
+++ b/examples/client-certificate/main.tf
@@ -23,7 +23,7 @@ terraform {
 # ------------------------------------------------------------------------------
 
 resource "google_sql_ssl_cert" "client_cert" {
-  provider    = "google-beta"
+  provider    = google-beta
   common_name = var.common_name
   instance    = var.database_instance_name
 }

--- a/examples/mysql-private-ip/main.tf
+++ b/examples/mysql-private-ip/main.tf
@@ -39,13 +39,13 @@ locals {
 
 # Simple network, auto-creates subnetworks
 resource "google_compute_network" "private_network" {
-  provider = "google-beta"
+  provider = google-beta
   name     = local.private_network_name
 }
 
 # Reserve global internal address range for the peering
 resource "google_compute_global_address" "private_ip_address" {
-  provider      = "google-beta"
+  provider      = google-beta
   name          = local.private_ip_name
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
@@ -55,7 +55,7 @@ resource "google_compute_global_address" "private_ip_address" {
 
 # Establish VPC network peering connection using the reserved address range
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider                = "google-beta"
+  provider                = google-beta
   network                 = google_compute_network.private_network.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]

--- a/examples/postgres-private-ip/main.tf
+++ b/examples/postgres-private-ip/main.tf
@@ -39,13 +39,13 @@ locals {
 
 # Simple network, auto-creates subnetworks
 resource "google_compute_network" "private_network" {
-  provider = "google-beta"
+  provider = google-beta
   name     = local.private_network_name
 }
 
 # Reserve global internal address range for the peering
 resource "google_compute_global_address" "private_ip_address" {
-  provider      = "google-beta"
+  provider      = google-beta
   name          = local.private_ip_name
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
@@ -55,7 +55,7 @@ resource "google_compute_global_address" "private_ip_address" {
 
 # Establish VPC network peering connection using the reserved address range
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider                = "google-beta"
+  provider                = google-beta
   network                 = google_compute_network.private_network.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]

--- a/main.tf
+++ b/main.tf
@@ -39,13 +39,13 @@ locals {
 
 # Simple network, auto-creates subnetworks
 resource "google_compute_network" "private_network" {
-  provider = "google-beta"
+  provider = google-beta
   name     = local.private_network_name
 }
 
 # Reserve global internal address range for the peering
 resource "google_compute_global_address" "private_ip_address" {
-  provider      = "google-beta"
+  provider      = google-beta
   name          = local.private_ip_name
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
@@ -55,7 +55,7 @@ resource "google_compute_global_address" "private_ip_address" {
 
 # Establish VPC network peering connection using the reserved address range
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider                = "google-beta"
+  provider                = google-beta
   network                 = google_compute_network.private_network.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]

--- a/modules/cloud-sql/main.tf
+++ b/modules/cloud-sql/main.tf
@@ -38,7 +38,7 @@ provider google-beta {
 resource "google_sql_database_instance" "master" {
   depends_on = [null_resource.dependency_getter]
 
-  provider         = "google-beta"
+  provider         = google-beta
   name             = var.name
   project          = var.project
   region           = var.region

--- a/modules/cloud-sql/main.tf
+++ b/modules/cloud-sql/main.tf
@@ -196,7 +196,7 @@ resource "google_sql_database_instance" "failover_replica" {
     google_sql_user.default,
   ]
 
-  provider         = "google-beta"
+  provider         = google-beta
   name             = "${var.name}-failover"
   project          = var.project
   region           = var.region
@@ -274,7 +274,7 @@ resource "google_sql_database_instance" "read_replica" {
     google_sql_user.default,
   ]
 
-  provider         = "google-beta"
+  provider         = google-beta
   name             = "${var.name}-read-${count.index}"
   project          = var.project
   region           = var.region


### PR DESCRIPTION
This is to avoid the deprecation warning we have been having when using this module.